### PR TITLE
Make all the sidebar messages translatable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation 'xyz.nucleoid:plasmid:0.4.46'
+	modImplementation 'xyz.nucleoid:plasmid:0.4.76'
 
 	modRuntime ("com.github.SuperCoder7979:databreaker:0.2.6") {
 		exclude module : "fabric-loader"

--- a/src/main/java/xyz/nucleoid/extras/NucleoidSidebar.java
+++ b/src/main/java/xyz/nucleoid/extras/NucleoidSidebar.java
@@ -40,8 +40,9 @@ public final class NucleoidSidebar {
     }
 
     private void writeSidebar(SidebarWidget.Content content) {
-        content.writeLine(Formatting.GOLD + "Welcome to Nucleoid!");
-        content.writeLine(Formatting.AQUA + "nucleoid.xyz/discord");
+        content.writeFormattedTranslated(Formatting.GOLD, "nucleoid.sidebar.welcome");
+
+        content.writeFormattedTranslated(Formatting.AQUA, "nucleoid.discord");
 
         Collection<ManagedGameSpace> openGames = ManagedGameSpace.getOpen();
         if (!openGames.isEmpty()) {
@@ -51,7 +52,7 @@ public final class NucleoidSidebar {
     }
 
     private void writeGamesToSidebar(SidebarWidget.Content content, Collection<ManagedGameSpace> openGames) {
-        content.writeLine(Formatting.GOLD + "Open games:");
+        content.writeFormattedTranslated(Formatting.GOLD, "nucleoid.sidebar.games");
 
         Stream<ManagedGameSpace> games = openGames.stream()
                 .sorted(Comparator.comparingInt(GameSpace::getPlayerCount).reversed())
@@ -68,8 +69,8 @@ public final class NucleoidSidebar {
         });
 
         content.writeLine("");
-        content.writeLine(Formatting.GRAY + "...run /game join");
-        content.writeLine(Formatting.GRAY + "or use the compass!");
+        content.writeFormattedTranslated(Formatting.GRAY, "nucleoid.sidebar.join");
+        content.writeFormattedTranslated(Formatting.GRAY, "nucleoid.sidebar.compass");
     }
 
     public void addPlayer(ServerPlayerEntity player) {

--- a/src/main/resources/data/nucleoid_extras/lang/en_us.json
+++ b/src/main/resources/data/nucleoid_extras/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "nucleoid.sidebar.welcome": "Welcome to Nucleoid!",
+  "nucleoid.sidebar.games": "Open games:",
+  "nucleoid.sidebar.join": "...run /game join",
+  "nucleoid.sidebar.compass": "or use the compass!",
+  "nucleoid.discord": "nucleoid.xyz/discord"
+}


### PR DESCRIPTION
This PR makes all the messages in the sidebar translatable using the new formatting methods from NucleoidMC/plasmid#98, and so depends on that being merged first.