### PR TITLE
Fixes for statistics

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
@@ -56,7 +56,7 @@ public class StatisticsIntegration {
         }
 
         // Do not send statistics for anonymous games to the backend
-        if (space.getMetadata().sourceConfig().source() != null) return;
+        if (space.getMetadata().sourceConfig().source() == null) return;
 
         UUID gameId = space.getMetadata().id();
 

--- a/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
@@ -53,7 +53,11 @@ public class StatisticsIntegration {
                 player.sendMessage(new LiteralText("+--------------------------------------+")
                         .formatted(Formatting.DARK_GRAY), false);
             }
+
         }
+
+        // Do not send statistics for anonymous games to the backend
+        if (space.getMetadata().sourceConfig().source() != null) return;
 
         UUID gameId = space.getMetadata().id();
 

--- a/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
@@ -53,7 +53,6 @@ public class StatisticsIntegration {
                 player.sendMessage(new LiteralText("+--------------------------------------+")
                         .formatted(Formatting.DARK_GRAY), false);
             }
-
         }
 
         // Do not send statistics for anonymous games to the backend

--- a/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/game/StatisticsIntegration.java
@@ -46,7 +46,7 @@ public class StatisticsIntegration {
                 stats.visitAllStatistics((key, value) -> {
                     if (!key.hidden()) {
                         player.sendMessage(new TranslatableText("text.nucleoid_extras.statistics.stat",
-                                new TranslatableText(key.getTranslationKey()), value), false);
+                                new TranslatableText(key.getTranslationKey()), roundForDisplay(value)), false);
                     }
                 });
 
@@ -85,6 +85,16 @@ public class StatisticsIntegration {
             JsonObject bundle = iter.next();
             iter.remove();
             this.sendBundle(bundle);
+        }
+    }
+
+    private static String roundForDisplay(Number number) {
+        if (number instanceof Double d) {
+            return String.format("%.2f", d);
+        } else if (number instanceof Float f) {
+            return String.format("%.2f", f);
+        } else {
+            return String.format("%s", number);
         }
     }
 


### PR DESCRIPTION
Fixes the following:
- Rounds float/double values to 2 decimal places when they are shown in chat
- Prevents sending statistics to the backend for anonymous games, but still shows them to players in chat (#24)