### PR TITLE
Add discord role syncronisation for commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,6 @@ dependencies {
 	modCompileOnly "maven.modrinth:styled-chat:1.2.0"
 	modCompileOnly "com.viaversion:viaversion-api:4.3.1"
 	modCompileOnly "dev.gegy:player-roles-api:1.5.2"
-	// Depend on the full mod to use internals that aren't in the API
-	modCompileOnly "dev.gegy:player-roles:1.5.2"
 
 	/*modRuntime ("supercoder79:databreaker:0.2.7") {
 		exclude module : "fabric-loader"

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,13 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	modImplementation 'xyz.nucleoid:plasmid:0.5+1.18.2-SNAPSHOT'
-	modImplementation include('xyz.nucleoid:more-codecs:0.1.5')
+	modImplementation include('xyz.nucleoid:more-codecs:0.2.2+1.18')
 
 	modCompileOnly "maven.modrinth:styled-chat:1.2.0"
 	modCompileOnly "com.viaversion:viaversion-api:4.3.1"
+	modCompileOnly "dev.gegy:player-roles-api:1.5.2"
+	// Depend on the full mod to use internals that aren't in the API
+	modCompileOnly "dev.gegy:player-roles:1.5.2"
 
 	/*modRuntime ("supercoder79:databreaker:0.2.7") {
 		exclude module : "fabric-loader"

--- a/src/main/java/xyz/nucleoid/extras/integrations/IntegrationsConfig.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/IntegrationsConfig.java
@@ -4,6 +4,8 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 public record IntegrationsConfig(
@@ -12,7 +14,8 @@ public record IntegrationsConfig(
         @Nullable String serverIp,
         boolean sendPlayers, boolean sendGames, boolean sendChat,
         boolean sendLifecycle, boolean sendPerformance,
-        boolean acceptRemoteCommands, boolean sendStatistics
+        boolean acceptRemoteCommands, boolean sendStatistics,
+        Map<String, Integer> discordPermissionMap, Map<String, String> discordRoleMap
 ) {
     public static final Codec<IntegrationsConfig> CODEC = RecordCodecBuilder.create(instance ->
         instance.group(
@@ -26,11 +29,13 @@ public record IntegrationsConfig(
                 Codec.BOOL.optionalFieldOf("send_lifecycle", true).forGetter(IntegrationsConfig::sendLifecycle),
                 Codec.BOOL.optionalFieldOf("send_performance", true).forGetter(IntegrationsConfig::sendPerformance),
                 Codec.BOOL.optionalFieldOf("accept_remote_commands", false).forGetter(IntegrationsConfig::acceptRemoteCommands),
-                Codec.BOOL.optionalFieldOf("send_statistics", false).forGetter(IntegrationsConfig::sendStatistics)
+                Codec.BOOL.optionalFieldOf("send_statistics", false).forGetter(IntegrationsConfig::sendStatistics),
+                Codec.unboundedMap(Codec.STRING, Codec.intRange(0, 4)).optionalFieldOf("discord_permission_map", Collections.emptyMap()).forGetter(IntegrationsConfig::discordPermissionMap),
+                Codec.unboundedMap(Codec.STRING, Codec.STRING).optionalFieldOf("discord_role_map", Collections.emptyMap()).forGetter(IntegrationsConfig::discordRoleMap)
         ).apply(instance, IntegrationsConfig::new)
     );
 
-    private IntegrationsConfig(String channel, String host, int port, Optional<String> serverIp, boolean sendPlayers, boolean sendGames, boolean sendChat, boolean sendLifecycle, boolean sendPerformance, boolean acceptRemoteCommands, boolean sendStatistics) {
-        this(channel, host, port, serverIp.orElse(null), sendPlayers, sendGames, sendChat, sendLifecycle, sendPerformance, acceptRemoteCommands, sendStatistics);
+    private IntegrationsConfig(String channel, String host, int port, Optional<String> serverIp, boolean sendPlayers, boolean sendGames, boolean sendChat, boolean sendLifecycle, boolean sendPerformance, boolean acceptRemoteCommands, boolean sendStatistics, Map<String, Integer> discordPermissionMap, Map<String, String> discordRoleMap) {
+        this(channel, host, port, serverIp.orElse(null), sendPlayers, sendGames, sendChat, sendLifecycle, sendPerformance, acceptRemoteCommands, sendStatistics, discordPermissionMap, discordRoleMap);
     }
 }

--- a/src/main/java/xyz/nucleoid/extras/integrations/relay/CommandSourceBuilder.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/relay/CommandSourceBuilder.java
@@ -1,0 +1,75 @@
+package xyz.nucleoid.extras.integrations.relay;
+
+import dev.gegy.roles.api.PlayerRolesApi;
+import dev.gegy.roles.api.Role;
+import dev.gegy.roles.api.RoleReader;
+import dev.gegy.roles.api.VirtualServerCommandSource;
+import dev.gegy.roles.api.override.RoleOverrideReader;
+import dev.gegy.roles.override.RoleOverrideMap;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public interface CommandSourceBuilder {
+    CommandSourceBuilder INSTANCE = FabricLoader.getInstance().isModLoaded("player_roles") ? new PlayerRoles() : new Vanilla();
+
+    ServerCommandSource buildCommandSource(CommandOutput output, MinecraftServer server, String name, int permissionLevel, List<String> roles);
+
+    final class Vanilla implements CommandSourceBuilder {
+        Vanilla() {
+        }
+
+        @Override
+        public ServerCommandSource buildCommandSource(CommandOutput output, MinecraftServer server, String name, int permissionLevel, List<String> roles) {
+            return new ServerCommandSource(output, Vec3d.ZERO, Vec2f.ZERO, server.getOverworld(), permissionLevel, name, new LiteralText(name), server, null);
+        }
+    }
+
+    final class PlayerRoles implements CommandSourceBuilder {
+        PlayerRoles() {
+        }
+
+        @Override
+        public ServerCommandSource buildCommandSource(CommandOutput output, MinecraftServer server, String name, int permissionLevel, List<String> roles) {
+            var resolvedRoles = new ArrayList<Role>();
+            var overrideMap = new RoleOverrideMap();
+            for (var roleId : roles) {
+                var role = PlayerRolesApi.provider().get(roleId);
+                if (role != null) {
+                    resolvedRoles.add(role);
+                }
+            }
+            resolvedRoles.sort(null);
+            for (var role : resolvedRoles) {
+                overrideMap.addAll(role.getOverrides());
+            }
+            var roleReader = new RoleReader() {
+                @NotNull
+                @Override
+                public Iterator<Role> iterator() {
+                    return resolvedRoles.iterator();
+                }
+
+                @Override
+                public boolean has(Role role) {
+                    return resolvedRoles.contains(role);
+                }
+
+                @Override
+                public RoleOverrideReader overrides() {
+                    return overrideMap;
+                }
+            };
+            return new VirtualServerCommandSource(roleReader, output, Vec3d.ZERO, Vec2f.ZERO, server.getOverworld(), permissionLevel, name, new LiteralText(name), server, null);
+        }
+    }
+}

--- a/src/main/java/xyz/nucleoid/extras/integrations/relay/RemoteCommandIntegration.java
+++ b/src/main/java/xyz/nucleoid/extras/integrations/relay/RemoteCommandIntegration.java
@@ -17,6 +17,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 
 public final class RemoteCommandIntegration {
+    private static final String DISCORD_EVERYONE_ROLE = "discord_everyone";
+
     private final ConcurrentLinkedQueue<RemoteCommand> commandQueue = new ConcurrentLinkedQueue<>();
 
     private final IntegrationSender systemSender;
@@ -36,7 +38,7 @@ public final class RemoteCommandIntegration {
                 var sender = body.get("sender").getAsString();
                 var discordRoles = body.get("roles").getAsJsonArray();
                 var roles = new ArrayList<String>();
-                roles.add("discord_everyone");
+                roles.add(DISCORD_EVERYONE_ROLE);
                 var permissionLevel = 0;
                 for (var roleId : discordRoles) {
                     var role = config.discordRoleMap().get(roleId.getAsString());


### PR DESCRIPTION
This introduces a soft dependency on player-roles(-api), along with new configuration options in the integrations config: discord_permission_map and discord_roles map:
```json5
{
  "integrations": {
    // *snip*

    // This specifies vanilla permission levels and can be used even when player-roles is not installed
    "discord_permission_map": {
      "123123123123123123": 4
    },
    // This specifies role names from player-roles. Every user is implicitly given the role discord_everyone as well to allow for base permission controls
    "discord_role_map": {
      "123123123123123123": "discord_core"
    }
  }
}
```
Both maps use the Discord IDs for the roles. This also depends on the new code pushed in NucleoidMC/nucleoid-backend@54e56a3