### PR TITLE
Change the layout of the navigator (open toggle)

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/game_portal/StyledMenuPortalBackend.java
+++ b/src/main/java/xyz/nucleoid/extras/game_portal/StyledMenuPortalBackend.java
@@ -122,34 +122,21 @@ public abstract class StyledMenuPortalBackend implements GamePortalBackend {
 
     private void fill(ServerPlayerEntity player, SimpleGui gui, boolean viewOpen) {
         var page = new MutableInt();
-        var all = new GuiElementBuilder(Items.COMPASS);
-        if (!viewOpen) {
-            all.glow();
-        } else {
-            all.setCallback(() -> {
-                this.fill(player, gui, false);
-                PagedGui.playClickSound(player);
-            });
-        }
-
-        gui.setSlot(5 * 9 + 3, all.setName(Text.translatable("nucleoid.navigator.all_games")));
-
-        var open = new GuiElementBuilder(Items.REDSTONE_TORCH);
-        if (viewOpen) {
-            open.glow();
-        } else {
-            open.setCallback(() -> {
-                this.fill(player, gui, true);
-                PagedGui.playClickSound(player);
-            });
-        }
-        gui.setSlot(5 * 9 + 5, open.setName(Text.translatable("nucleoid.navigator.open_games")));
+        var filter = new GuiElementBuilder(viewOpen ? Items.SOUL_LANTERN : Items.LANTERN);
+        filter.setCallback(() -> {
+            this.fill(player, gui, !viewOpen);
+            PagedGui.playClickSound(player);
+        });
 
         if (viewOpen) {
+            filter.glow();
+            gui.setTitle(this.uiTitle.copy().append(Text.of(" ")).append(Text.translatable("nucleoid.navigator.open_only")));
             this.fillOpen(player, gui, page);
         } else {
+            gui.setTitle(this.uiTitle);
             this.fillInterface(player, gui, page);
         }
+        gui.setSlot(5 * 9 + 4, filter.setName(Text.translatable(viewOpen ? "nucleoid.navigator.open_games" : "nucleoid.navigator.all_games")));
     }
 
     private void fillOpen(ServerPlayerEntity player, SimpleGui gui, MutableInt page) {

--- a/src/main/resources/data/nucleoid_extras/lang/en_us.json
+++ b/src/main/resources/data/nucleoid_extras/lang/en_us.json
@@ -19,8 +19,9 @@
   "nucleoid.stop.scheduled.already": "Server restart has already been scheduled.",
   "nucleoid.stop.game.open": "Cannot join this game: a server stop has been scheduled!",
 
-  "nucleoid.navigator.all_games": "View Games",
-  "nucleoid.navigator.open_games": "View Active",
+  "nucleoid.navigator.all_games": "All Games",
+  "nucleoid.navigator.open_games": "Open Games",
+  "nucleoid.navigator.open_only": "(Open only)",
 
   "block.nucleoid_extras.end_portal": "End Portal (Lobby only!)",
   "block.nucleoid_extras.end_gateway": "End Gateway (Lobby only!)",


### PR DESCRIPTION
This PR tweaks the layout of the navigator to be more intuitive.
There is now one button at the bottom row that toggles on and off the filter for viewing only open games.
This also adds "(Open only)" to the GUI's title.