### PR TITLE
Add transient doors

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/lobby/NEBlocks.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/NEBlocks.java
@@ -65,6 +65,19 @@ public class NEBlocks {
     public static final Block SNAKE_BLOCK = new SnakeBlock(AbstractBlock.Settings.copy(Blocks.LIME_CONCRETE).strength(100), Blocks.LIME_CONCRETE, 8, 7);
     public static final Block FAST_SNAKE_BLOCK = new SnakeBlock(AbstractBlock.Settings.copy(Blocks.LIGHT_BLUE_CONCRETE).strength(100), Blocks.LIGHT_BLUE_CONCRETE, 4, 7);
 
+    public static final Block TRANSIENT_IRON_DOOR = new TransientDoorBlock(Blocks.IRON_DOOR);
+    public static final Block TRANSIENT_OAK_DOOR = new TransientDoorBlock(Blocks.OAK_DOOR);
+    public static final Block TRANSIENT_SPRUCE_DOOR = new TransientDoorBlock(Blocks.SPRUCE_DOOR);
+    public static final Block TRANSIENT_BIRCH_DOOR = new TransientDoorBlock(Blocks.BIRCH_DOOR);
+    public static final Block TRANSIENT_JUNGLE_DOOR = new TransientDoorBlock(Blocks.JUNGLE_DOOR);
+    public static final Block TRANSIENT_ACACIA_DOOR = new TransientDoorBlock(Blocks.ACACIA_DOOR);
+    public static final Block TRANSIENT_CHERRY_DOOR = new TransientDoorBlock(Blocks.CHERRY_DOOR);
+    public static final Block TRANSIENT_DARK_OAK_DOOR = new TransientDoorBlock(Blocks.DARK_OAK_DOOR);
+    public static final Block TRANSIENT_MANGROVE_DOOR = new TransientDoorBlock(Blocks.MANGROVE_DOOR);
+    public static final Block TRANSIENT_BAMBOO_DOOR = new TransientDoorBlock(Blocks.BAMBOO_DOOR);
+    public static final Block TRANSIENT_CRIMSON_DOOR = new TransientDoorBlock(Blocks.CRIMSON_DOOR);
+    public static final Block TRANSIENT_WARPED_DOOR = new TransientDoorBlock(Blocks.WARPED_DOOR);
+
     public static final Block NUCLE_PAST_LOGO = createTaterBlock(new DustParticleEffect(Vec3d.unpackRgb(0x52C471).toVector3f(), 1), "65ed3e4d6ec42bd84d2b5e452087d454aac141a978540f6d200bd8aa863d4db8");
 
     public static final Block TINY_POTATO = createTaterBlock(ParticleTypes.HEART, "573514a23245f15dbad5fb4e622163020864cce4c15d56de3adb90fa5a7137fd");
@@ -511,6 +524,19 @@ public class NEBlocks {
         register("infinite_dropper", INFINITE_DROPPER);
         register("snake_block", SNAKE_BLOCK);
         register("fast_snake_block", FAST_SNAKE_BLOCK);
+
+        register("transient_iron_door", TRANSIENT_IRON_DOOR);
+        register("transient_oak_door", TRANSIENT_OAK_DOOR);
+        register("transient_spruce_door", TRANSIENT_SPRUCE_DOOR);
+        register("transient_birch_door", TRANSIENT_BIRCH_DOOR);
+        register("transient_jungle_door", TRANSIENT_JUNGLE_DOOR);
+        register("transient_acacia_door", TRANSIENT_ACACIA_DOOR);
+        register("transient_cherry_door", TRANSIENT_CHERRY_DOOR);
+        register("transient_dark_oak_door", TRANSIENT_DARK_OAK_DOOR);
+        register("transient_mangrove_door", TRANSIENT_MANGROVE_DOOR);
+        register("transient_bamboo_door", TRANSIENT_BAMBOO_DOOR);
+        register("transient_crimson_door", TRANSIENT_CRIMSON_DOOR);
+        register("transient_warped_door", TRANSIENT_WARPED_DOOR);
 
         register("black_concrete_powder", BLACK_CONCRETE_POWDER);
         register("blue_concrete_powder", BLUE_CONCRETE_POWDER);

--- a/src/main/java/xyz/nucleoid/extras/lobby/NEItems.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/NEItems.java
@@ -53,6 +53,18 @@ public class NEItems {
             entries.add(NEItems.INFINITE_DROPPER);
             entries.add(NEItems.SNAKE_BLOCK);
             entries.add(NEItems.FAST_SNAKE_BLOCK);
+            entries.add(NEItems.TRANSIENT_IRON_DOOR);
+            entries.add(NEItems.TRANSIENT_OAK_DOOR);
+            entries.add(NEItems.TRANSIENT_SPRUCE_DOOR);
+            entries.add(NEItems.TRANSIENT_BIRCH_DOOR);
+            entries.add(NEItems.TRANSIENT_JUNGLE_DOOR);
+            entries.add(NEItems.TRANSIENT_ACACIA_DOOR);
+            entries.add(NEItems.TRANSIENT_CHERRY_DOOR);
+            entries.add(NEItems.TRANSIENT_DARK_OAK_DOOR);
+            entries.add(NEItems.TRANSIENT_MANGROVE_DOOR);
+            entries.add(NEItems.TRANSIENT_BAMBOO_DOOR);
+            entries.add(NEItems.TRANSIENT_CRIMSON_DOOR);
+            entries.add(NEItems.TRANSIENT_WARPED_DOOR);
             entries.add(NEItems.BLACK_CONCRETE_POWDER);
             entries.add(NEItems.BLUE_CONCRETE_POWDER);
             entries.add(NEItems.BROWN_CONCRETE_POWDER);
@@ -92,6 +104,19 @@ public class NEItems {
     public static final Item INFINITE_DROPPER = createSimple(NEBlocks.INFINITE_DROPPER, Items.DROPPER);
     public static final Item SNAKE_BLOCK = createSimple(NEBlocks.SNAKE_BLOCK, Items.LIME_CONCRETE);
     public static final Item FAST_SNAKE_BLOCK = createSimple(NEBlocks.FAST_SNAKE_BLOCK, Items.LIGHT_BLUE_CONCRETE);
+
+    public static final Item TRANSIENT_IRON_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_IRON_DOOR, new Item.Settings(), Items.IRON_DOOR);
+    public static final Item TRANSIENT_OAK_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_OAK_DOOR, new Item.Settings(), Items.OAK_DOOR);
+    public static final Item TRANSIENT_SPRUCE_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_SPRUCE_DOOR, new Item.Settings(), Items.SPRUCE_DOOR);
+    public static final Item TRANSIENT_BIRCH_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_BIRCH_DOOR, new Item.Settings(), Items.BIRCH_DOOR);
+    public static final Item TRANSIENT_JUNGLE_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_JUNGLE_DOOR, new Item.Settings(), Items.JUNGLE_DOOR);
+    public static final Item TRANSIENT_ACACIA_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_ACACIA_DOOR, new Item.Settings(), Items.ACACIA_DOOR);
+    public static final Item TRANSIENT_CHERRY_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_CHERRY_DOOR, new Item.Settings(), Items.CHERRY_DOOR);
+    public static final Item TRANSIENT_DARK_OAK_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_DARK_OAK_DOOR, new Item.Settings(), Items.DARK_OAK_DOOR);
+    public static final Item TRANSIENT_MANGROVE_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_MANGROVE_DOOR, new Item.Settings(), Items.MANGROVE_DOOR);
+    public static final Item TRANSIENT_BAMBOO_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_BAMBOO_DOOR, new Item.Settings(), Items.BAMBOO_DOOR);
+    public static final Item TRANSIENT_CRIMSON_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_CRIMSON_DOOR, new Item.Settings(), Items.CRIMSON_DOOR);
+    public static final Item TRANSIENT_WARPED_DOOR = new LobbyTallBlockItem(NEBlocks.TRANSIENT_WARPED_DOOR, new Item.Settings(), Items.WARPED_DOOR);
 
     public static final Item BLACK_CONCRETE_POWDER = createSimple(NEBlocks.BLACK_CONCRETE_POWDER, Items.BLACK_CONCRETE_POWDER);
     public static final Item BLUE_CONCRETE_POWDER = createSimple(NEBlocks.BLUE_CONCRETE_POWDER, Items.BLUE_CONCRETE_POWDER);
@@ -433,6 +458,19 @@ public class NEItems {
         register("infinite_dropper", INFINITE_DROPPER);
         register("snake_block", SNAKE_BLOCK);
         register("fast_snake_block", FAST_SNAKE_BLOCK);
+
+        register("transient_iron_door", TRANSIENT_IRON_DOOR);
+        register("transient_oak_door", TRANSIENT_OAK_DOOR);
+        register("transient_spruce_door", TRANSIENT_SPRUCE_DOOR);
+        register("transient_birch_door", TRANSIENT_BIRCH_DOOR);
+        register("transient_jungle_door", TRANSIENT_JUNGLE_DOOR);
+        register("transient_acacia_door", TRANSIENT_ACACIA_DOOR);
+        register("transient_cherry_door", TRANSIENT_CHERRY_DOOR);
+        register("transient_dark_oak_door", TRANSIENT_DARK_OAK_DOOR);
+        register("transient_mangrove_door", TRANSIENT_MANGROVE_DOOR);
+        register("transient_bamboo_door", TRANSIENT_BAMBOO_DOOR);
+        register("transient_crimson_door", TRANSIENT_CRIMSON_DOOR);
+        register("transient_warped_door", TRANSIENT_WARPED_DOOR);
 
         register("black_concrete_powder", BLACK_CONCRETE_POWDER);
         register("blue_concrete_powder", BLUE_CONCRETE_POWDER);

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/TransientDoorBlock.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/TransientDoorBlock.java
@@ -1,0 +1,63 @@
+package xyz.nucleoid.extras.lobby.block;
+
+import eu.pb4.polymer.core.api.block.PolymerBlock;
+import net.minecraft.SharedConstants;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockSetType;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.DoorBlock;
+import net.minecraft.block.enums.DoubleBlockHalf;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.World;
+
+public class TransientDoorBlock extends DoorBlock implements PolymerBlock {
+    private static final int CLOSE_DELAY = SharedConstants.TICKS_PER_SECOND * 10;
+
+    private static final double RECHECK_RANGE = 8;
+    private static final int RECHECK_DELAY = SharedConstants.TICKS_PER_SECOND * 1;
+
+    private final Block polymerBlock;
+
+    public TransientDoorBlock(Block block) {
+        super(AbstractBlock.Settings.copy(block), block instanceof DoorBlock door ? door.getBlockSetType() : BlockSetType.OAK);
+        this.polymerBlock = block;
+    }
+
+    private void scheduleClose(World world, BlockPos pos, boolean recheck) {
+        world.scheduleBlockTick(pos, this, recheck ? RECHECK_DELAY : CLOSE_DELAY);
+    }
+
+    @Override
+    public void onBlockAdded(BlockState state, World world, BlockPos pos, BlockState oldState, boolean notify) {
+        if (state.get(HALF) == DoubleBlockHalf.LOWER && state.get(OPEN) && (!oldState.isOf(this) || !oldState.get(OPEN))) {
+            this.scheduleClose(world, pos, false);
+        }
+    }
+
+    @Override
+    public void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
+        var box = new Box(pos).expand(RECHECK_RANGE);
+        var entities = world.getNonSpectatingEntities(PlayerEntity.class, box);
+
+        if (entities.isEmpty()) {
+            this.setOpen(null, world, state, pos, false);
+        } else {
+            this.scheduleClose(world, pos, true);
+        }
+    }
+
+    @Override
+    public Block getPolymerBlock(BlockState state) {
+        return this.polymerBlock;
+    }
+
+    @Override
+    public BlockState getPolymerBlockState(BlockState state) {
+        return this.polymerBlock.getStateWithProperties(state);
+    }
+}

--- a/src/main/java/xyz/nucleoid/extras/lobby/item/LobbyTallBlockItem.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/item/LobbyTallBlockItem.java
@@ -1,0 +1,28 @@
+package xyz.nucleoid.extras.lobby.item;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class LobbyTallBlockItem extends LobbyBlockItem {
+    private static final int UP_FLAGS = Block.FORCE_STATE | Block.REDRAW_ON_MAIN_THREAD | Block.NOTIFY_ALL;
+
+    public LobbyTallBlockItem(Block block, Settings settings, Item virtualItem) {
+        super(block, settings, virtualItem);
+    }
+
+    protected boolean place(ItemPlacementContext context, BlockState state) {
+        World world = context.getWorld();
+
+        BlockPos upPos = context.getBlockPos().up();
+        BlockState upState = world.isWater(upPos) ? Blocks.WATER.getDefaultState() : Blocks.AIR.getDefaultState();
+
+        world.setBlockState(upPos, upState, UP_FLAGS);
+
+        return super.place(context, state);
+    }
+}

--- a/src/main/resources/data/minecraft/tags/blocks/doors.json
+++ b/src/main/resources/data/minecraft/tags/blocks/doors.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "nucleoid_extras:transient_iron_door"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/wooden_doors.json
+++ b/src/main/resources/data/minecraft/tags/blocks/wooden_doors.json
@@ -1,0 +1,15 @@
+{
+  "values": [
+    "nucleoid_extras:transient_oak_door",
+    "nucleoid_extras:transient_spruce_door",
+    "nucleoid_extras:transient_birch_door",
+    "nucleoid_extras:transient_jungle_door",
+    "nucleoid_extras:transient_acacia_door",
+    "nucleoid_extras:transient_cherry_door",
+    "nucleoid_extras:transient_dark_oak_door",
+    "nucleoid_extras:transient_mangrove_door",
+    "nucleoid_extras:transient_bamboo_door",
+    "nucleoid_extras:transient_crimson_door",
+    "nucleoid_extras:transient_warped_door"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/doors.json
+++ b/src/main/resources/data/minecraft/tags/items/doors.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "nucleoid_extras:transient_iron_door"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/wooden_doors.json
+++ b/src/main/resources/data/minecraft/tags/items/wooden_doors.json
@@ -1,0 +1,15 @@
+{
+  "values": [
+    "nucleoid_extras:transient_oak_door",
+    "nucleoid_extras:transient_spruce_door",
+    "nucleoid_extras:transient_birch_door",
+    "nucleoid_extras:transient_jungle_door",
+    "nucleoid_extras:transient_acacia_door",
+    "nucleoid_extras:transient_cherry_door",
+    "nucleoid_extras:transient_dark_oak_door",
+    "nucleoid_extras:transient_mangrove_door",
+    "nucleoid_extras:transient_bamboo_door",
+    "nucleoid_extras:transient_crimson_door",
+    "nucleoid_extras:transient_warped_door"
+  ]
+}

--- a/src/main/resources/data/nucleoid_extras/lang/en_us.json
+++ b/src/main/resources/data/nucleoid_extras/lang/en_us.json
@@ -34,6 +34,18 @@
   "block.nucleoid_extras.snake_block": "Snake Block (Lobby only!)",
   "block.nucleoid_extras.fast_snake_block": "Fast Snake Block (Lobby only!)",
 
+  "block.nucleoid_extras.transient_iron_door": "Transient Iron Door (Lobby only!)",
+  "block.nucleoid_extras.transient_oak_door": "Transient Oak Door (Lobby only!)",
+  "block.nucleoid_extras.transient_spruce_door": "Transient Spruce Door (Lobby only!)",
+  "block.nucleoid_extras.transient_birch_door": "Transient Birch Door (Lobby only!)",
+  "block.nucleoid_extras.transient_jungle_door": "Transient Jungle Door (Lobby only!)",
+  "block.nucleoid_extras.transient_acacia_door": "Transient Acacia Door (Lobby only!)",
+  "block.nucleoid_extras.transient_cherry_door": "Transient Cherry Door (Lobby only!)",
+  "block.nucleoid_extras.transient_mangrove_door": "Transient Mangrove Door (Lobby only!)",
+  "block.nucleoid_extras.transient_bamboo_door": "Transient Bamboo Door (Lobby only!)",
+  "block.nucleoid_extras.transient_crimson_door": "Transient Crimson Door (Lobby only!)",
+  "block.nucleoid_extras.transient_warped_door": "Transient Warped Door (Lobby only!)",
+
   "block.nucleoid_extras.black_concrete_powder": "Floating Black Concrete Powder (Lobby only!)",
   "block.nucleoid_extras.blue_concrete_powder": "Floating Blue Concrete Powder (Lobby only!)",
   "block.nucleoid_extras.brown_concrete_powder": "Floating Brown Concrete Powder (Lobby only!)",


### PR DESCRIPTION
Transient doors are similar to doors but automatically close after a short period of time when no players are nearby. They can be used in the lobby as doors that can be interacted with but automatically return to a default state once the player is done using them.