### PR TITLE
Add light taters

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/lobby/NEBlocks.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/NEBlocks.java
@@ -254,6 +254,7 @@ public class NEBlocks {
     public static final Block HONEYCOMB_TATER = createTaterBlock(ParticleTypes.LANDING_HONEY, "e917928e35f2fac59aa1d14d80c478f38d14e2f66ee59d4eb9d025605406481");
     public static final Block HORN_CORAL_TATER = createTaterBlock(ParticleTypes.BUBBLE, "3e17f4d2977dafce018ac06163f2a7c5672855d198da86fa050f27a7c45b2da4");
     public static final Block JUNGLE_TATER = createTaterBlock(Blocks.JUNGLE_PLANKS, "b9105eebf99ec35ac08aaa2ed8ac721590adbdb1eb3a158a82c11e71e76d28aa");
+    public static final Block LIGHT_TATER = createLightTaterBlock("640ed4ea72aed9503c0519d3380ac480a20f9155c428d0571ad767eb4e8973b4");
     public static final Block MYCELIUM_TATER = createTaterBlock(ParticleTypes.MYCELIUM, "f3447bbb99321b399b7a1913d9bc4e90e8b0fc9b9520af45a8f59a1540d4b620");
     public static final Block NETHER_WART_TATER = createTaterBlock(ParticleTypes.CRIMSON_SPORE, "81c05e8c91a4ca83120799053270dfd7fdf1376988a1a393645140ae89eb6762");
     public static final Block OAK_TATER = createTaterBlock(Blocks.OAK_PLANKS, "28cfc208966e2f5206b1aba0489e5fdb3f05e6d94befbc618ad80e74eb1016d2");
@@ -510,6 +511,10 @@ public class NEBlocks {
         return new MarkerTaterBlock(createTaterBlockSettings(), particleBlock, texture);
     }
 
+    private static Block createLightTaterBlock(String texture) {
+        return new LightTaterBlock(createTaterBlockSettings(), texture);
+    }
+
     public static void register() {
         register("nucleoid_logo", NUCLEOID_LOGO);
         register("nucle_past_logo", NUCLE_PAST_LOGO);
@@ -679,6 +684,7 @@ public class NEBlocks {
         register("honeycomb_tater", HONEYCOMB_TATER);
         register("horn_coral_tater", HORN_CORAL_TATER);
         register("jungle_tater", JUNGLE_TATER);
+        register("light_tater", LIGHT_TATER);
         register("mycelium_tater", MYCELIUM_TATER);
         register("nether_wart_tater", NETHER_WART_TATER);
         register("oak_tater", OAK_TATER);

--- a/src/main/java/xyz/nucleoid/extras/lobby/NEItems.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/NEItems.java
@@ -258,6 +258,7 @@ public class NEItems {
     public static final Item HONEYCOMB_TATER = createHead(NEBlocks.HONEYCOMB_TATER);
     public static final Item HORN_CORAL_TATER = createHead(NEBlocks.HORN_CORAL_TATER);
     public static final Item JUNGLE_TATER = createHead(NEBlocks.JUNGLE_TATER);
+    public static final Item LIGHT_TATER = createHead(NEBlocks.LIGHT_TATER);
     public static final Item MYCELIUM_TATER = createHead(NEBlocks.MYCELIUM_TATER);
     public static final Item NETHER_WART_TATER = createHead(NEBlocks.NETHER_WART_TATER);
     public static final Item OAK_TATER = createHead(NEBlocks.OAK_TATER);
@@ -616,6 +617,7 @@ public class NEItems {
         registerTater("honeycomb_tater", HONEYCOMB_TATER);
         registerTater("horn_coral_tater", HORN_CORAL_TATER);
         registerTater("jungle_tater", JUNGLE_TATER);
+        registerTater("light_tater", LIGHT_TATER);
         registerTater("mycelium_tater", MYCELIUM_TATER);
         registerTater("nether_wart_tater", NETHER_WART_TATER);
         registerTater("oak_tater", OAK_TATER);

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/tater/LightTaterBlock.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/tater/LightTaterBlock.java
@@ -1,0 +1,45 @@
+package xyz.nucleoid.extras.lobby.block.tater;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.LightBlock;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.particle.BlockStateParticleEffect;
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+
+public class LightTaterBlock extends MarkerTaterBlock {
+    public LightTaterBlock(Settings settings, String texture) {
+        super(settings, Blocks.LIGHT, texture);
+    }
+
+    @Override
+    public ParticleEffect getBlockParticleEffect(BlockState state, ServerWorld world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+        return getLightParticle(world.getLightLevel(pos));
+    }
+
+    @Override
+    public double getPlayerParticleYOffset() {
+        return 3;
+    }
+
+    @Override
+    public ParticleEffect getPlayerParticleEffect(ServerPlayerEntity player) {
+        BlockPos pos = BlockPos.ofFloored(player.getX(), player.getY() + this.getPlayerParticleYOffset(), player.getZ());
+
+        return getLightParticle(player.getWorld().getLightLevel(pos));
+    }
+
+    private static BlockState getLightState(int level) {
+        return Blocks.LIGHT.getDefaultState().with(LightBlock.LEVEL_15, level);
+    }
+
+    private static ParticleEffect getLightParticle(int level) {
+        return new BlockStateParticleEffect(ParticleTypes.BLOCK_MARKER, getLightState(level));
+    }
+}

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/tater/MarkerTaterBlock.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/tater/MarkerTaterBlock.java
@@ -18,13 +18,17 @@ public class MarkerTaterBlock extends CubicPotatoBlock {
         this(settings, particleBlock.getDefaultState(), texture);
     }
 
+    public double getPlayerParticleYOffset() {
+        return 0.5;
+    }
+
     @Override
     public void spawnPlayerParticles(ServerPlayerEntity player) {
         ParticleEffect particleEffect = this.getPlayerParticleEffect(player);
 
         if (particleEffect != null) {
             double x = player.getX();
-            double y = player.getY() + 0.5;
+            double y = player.getY() + this.getPlayerParticleYOffset();
             double z = player.getZ();
 
             player.getServerWorld().spawnParticles(particleEffect, x, y, z, 1, 0, 0, 0, 0);

--- a/src/main/resources/data/nucleoid_extras/lang/en_us.json
+++ b/src/main/resources/data/nucleoid_extras/lang/en_us.json
@@ -180,6 +180,7 @@
   "block.nucleoid_extras.honeycomb_tater": "Honeycomb Tater",
   "block.nucleoid_extras.horn_coral_tater": "Horn Coral Tater",
   "block.nucleoid_extras.jungle_tater": "Jungle Tater",
+  "block.nucleoid_extras.light_tater": "Light Tater",
   "block.nucleoid_extras.mycelium_tater": "Mycelium Tater",
   "block.nucleoid_extras.nether_wart_tater": "Nether Wart Tater",
   "block.nucleoid_extras.oak_tater": "Oak Tater",


### PR DESCRIPTION
This pull request adds light taters, which display a light block marker particle indicating the current light level at the block or player's position.

<img width="468" alt="Light taters" src="https://github.com/NucleoidMC/nucleoid-extras/assets/24855774/4be81513-133a-4b3b-a273-aa08da92b2e3">