### PR TITLE
Fix tater collection preventing interaction

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/lobby/NEItems.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/NEItems.java
@@ -839,9 +839,7 @@ public class NEItems {
             BlockPos pos = hitResult.getBlockPos();
 
             PlayerLobbyState state = PlayerLobbyState.get(player);
-            ActionResult result = state.collectTaterFromBlock(world, pos, stack, player);
-
-            return result;
+            state.collectTaterFromBlock(world, pos, stack, player);
         }
 
         return ActionResult.PASS;
@@ -853,9 +851,7 @@ public class NEItems {
             Vec3d hitPos = hitResult.getPos().subtract(entity.getPos());
 
             PlayerLobbyState state = PlayerLobbyState.get(player);
-            ActionResult result = state.collectTaterFromEntity(entity, hitPos, stack, player);
-
-            return result;
+            state.collectTaterFromEntity(entity, hitPos, stack, player);
         }
 
         return ActionResult.PASS;


### PR DESCRIPTION
A bug was introduced in #150 which prevented taters from being interacted with because tater collection was attempted first, short-circuiting the entire interaction. This pull request resolves this bug by removing the short-circuiting behavior of tater collection.