### PR TITLE
Allow lucky taters to break existing drops

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/lobby/block/tater/LuckyTaterDropPos.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/tater/LuckyTaterDropPos.java
@@ -1,0 +1,17 @@
+package xyz.nucleoid.extras.lobby.block.tater;
+
+import net.minecraft.util.math.BlockPos;
+
+public sealed interface LuckyTaterDropPos {
+    public record Allowed(BlockPos pos) implements LuckyTaterDropPos {}
+
+    public record Blocked(BlockPos pos) implements LuckyTaterDropPos {}
+
+    public final class None implements LuckyTaterDropPos {
+        public static final None INSTANCE = new None();
+
+        private None() {
+            return;
+        }
+    }
+}

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/tater/LuckyTaterPhase.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/tater/LuckyTaterPhase.java
@@ -1,0 +1,27 @@
+package xyz.nucleoid.extras.lobby.block.tater;
+
+import net.minecraft.util.StringIdentifiable;
+
+public enum LuckyTaterPhase implements StringIdentifiable {
+    READY("ready", 0),
+    BUILDING_COURAGE("building_courage", 1),
+    COOLDOWN("cooldown", 15),
+    ;
+
+    private final String name;
+    private final int comparatorOutput;
+
+    private LuckyTaterPhase(String name, int comparatorOutput) {
+        this.name = name;
+        this.comparatorOutput = comparatorOutput;
+    }
+
+    @Override
+    public String asString() {
+        return this.name;
+    }
+
+    public int getComparatorOutput() {
+        return this.comparatorOutput;
+    }
+}


### PR DESCRIPTION
Currently, if no player can collect a tater dropped by a lucky tater (whether because it is not fickle or because it has already been collected), the lucky tater cannot drop a tater in place of the existing dropped tater. This pull request modifies lucky tater functionality to break any existing dropped taters that would otherwise block a new tater from being dropped.