### PR TITLE
Use player context to create tater box tooltips

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/lobby/PlayerLobbyState.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/PlayerLobbyState.java
@@ -3,6 +3,7 @@ package xyz.nucleoid.extras.lobby;
 import eu.pb4.playerdata.api.PlayerDataApi;
 import eu.pb4.playerdata.api.storage.JsonDataStorage;
 import eu.pb4.playerdata.api.storage.PlayerDataStorage;
+import eu.pb4.polymer.core.api.utils.PolymerUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
@@ -82,10 +83,6 @@ public class PlayerLobbyState {
     private ActionResult collectTater(Block block, ItemStack stack, PlayerEntity player) {
         if (!(block instanceof TinyPotatoBlock tater)) return ActionResult.PASS;
 
-        if (stack.getItem() instanceof TaterBoxItem) {
-            stack.getOrCreateNbt().putUuid(TaterBoxItem.OWNER_KEY, player.getUuid());
-        }
-
         boolean alreadyAdded = this.collectedTaters.contains(tater);
         Text message;
 
@@ -93,6 +90,9 @@ public class PlayerLobbyState {
             message = Text.translatable("text.nucleoid_extras.tater_box.already_added", block.getName()).formatted(Formatting.RED);
         } else {
             this.collectedTaters.add(tater);
+
+            // Update the tooltip of tater boxes in player's inventory
+            PolymerUtils.reloadInventory((ServerPlayerEntity) player);
 
             message = Text.translatable("text.nucleoid_extras.tater_box.added", block.getName());
         }

--- a/src/main/java/xyz/nucleoid/extras/lobby/item/tater/TaterBoxItem.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/item/tater/TaterBoxItem.java
@@ -36,7 +36,6 @@ public class TaterBoxItem extends Item implements PolymerItem, Equipment {
     private static final Text NOT_OWNER_MESSAGE = Text.translatable("text.nucleoid_extras.tater_box.not_owner").formatted(Formatting.RED);
     public static final Text NONE_TEXT = Text.translatable("text.nucleoid_extras.tater_box.none");
 
-    public static final String OWNER_KEY = "Owner";
     private static final String LEGACY_TATERS_KEY = "Taters";
     private static final String SELECTED_TATER_KEY = "SelectedTater";
     private static final int COLOR = 0xCEADAA;
@@ -46,17 +45,6 @@ public class TaterBoxItem extends Item implements PolymerItem, Equipment {
 
     public TaterBoxItem(Settings settings) {
         super(settings);
-    }
-
-    private ActionResult isOwner(ItemStack stack, PlayerEntity player) {
-        NbtCompound tag = stack.getNbt();
-        if (tag == null) return ActionResult.PASS;
-        
-        if (!tag.contains(OWNER_KEY, NbtElement.LIST_TYPE)) return ActionResult.PASS;
-        UUID uuid = tag.getUuid(OWNER_KEY);
-        if (uuid == null) return ActionResult.PASS;
-
-        return player.getUuid().equals(uuid) ? ActionResult.SUCCESS : ActionResult.FAIL;
     }
 
     private MutableText getTitle(ServerPlayerEntity player) {
@@ -144,7 +132,7 @@ public class TaterBoxItem extends Item implements PolymerItem, Equipment {
         guiElementBuilder.hideFlags();
         guiElementBuilder.setCallback((index, type, action, gui) -> {
             ItemStack newStack = hand == null ? stack : user.getStackInHand(hand);
-            if (found && this == newStack.getItem() && this.isOwner(newStack, user) != ActionResult.FAIL) {
+            if (found && this == newStack.getItem()) {
                 TaterBoxItem.setSelectedTater(newStack, taterId);
                 gui.close();
             }
@@ -198,7 +186,7 @@ public class TaterBoxItem extends Item implements PolymerItem, Equipment {
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext context) {
         super.appendTooltip(stack, world, tooltip, context);
 
-        var owner = getOwnerPlayer(stack, world);
+        var owner = PolymerUtils.getPlayerContext();
 
         Block selectedBlock = getSelectedTater(stack);
         Text selectedName;
@@ -216,16 +204,6 @@ public class TaterBoxItem extends Item implements PolymerItem, Equipment {
         String percent = String.format("%.2f", count / (double) max * 100);
 
         tooltip.add(Text.translatable("text.nucleoid_extras.tater_box.completion", count, max, percent).formatted(Formatting.GRAY));
-    }
-
-    private PlayerEntity getOwnerPlayer(ItemStack stack, World world) {
-        if (!stack.hasNbt() || !stack.getNbt().contains(OWNER_KEY)) {
-            return null;
-        }
-
-        var owner = stack.getNbt().getUuid(OWNER_KEY);
-
-        return world.getPlayerByUuid(owner);
     }
 
     @Nullable


### PR DESCRIPTION
This pull request uses Polymer's player context to determine the tater box owner for the tater box's tooltip. This change should hopefully improve situations where the tooltip would incorrectly indicate that no taters have been collected.