### PR TITLE
Add separate block entity types for infinite dispensers and droppers

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/lobby/NEBlocks.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/NEBlocks.java
@@ -440,6 +440,8 @@ public class NEBlocks {
 
     public static final BlockEntityType<LaunchPadBlockEntity> LAUNCH_PAD_ENTITY = FabricBlockEntityTypeBuilder.create(LaunchPadBlockEntity::new, GOLD_LAUNCH_PAD, IRON_LAUNCH_PAD).build();
     public static final BlockEntityType<ContributorStatueBlockEntity> CONTRIBUTOR_STATUE_ENTITY = FabricBlockEntityTypeBuilder.create(ContributorStatueBlockEntity::new, CONTRIBUTOR_STATUE).build();
+    public static final BlockEntityType<InfiniteDispenserBlockEntity> INFINITE_DISPENSER_ENTITY = FabricBlockEntityTypeBuilder.create(InfiniteDispenserBlockEntity::new, INFINITE_DISPENSER).build();
+    public static final BlockEntityType<InfiniteDropperBlockEntity> INFINITE_DROPPER_ENTITY = FabricBlockEntityTypeBuilder.create(InfiniteDropperBlockEntity::new, INFINITE_DROPPER).build();
     public static final BlockEntityType<TateroidBlockEntity> TATEROID_ENTITY = FabricBlockEntityTypeBuilder.create(TateroidBlockEntity::new, TATEROID, RED_TATEROID, ORANGE_TATEROID, YELLOW_TATEROID, GREEN_TATEROID, BLUE_TATEROID, PURPLE_TATEROID).build();
     public static final BlockEntityType<DaylightDetectorTaterBlockEntity> DAYLIGHT_DETECTOR_TATER_ENTITY = FabricBlockEntityTypeBuilder.create(DaylightDetectorTaterBlockEntity::new, DAYLIGHT_DETECTOR_TATER, INVERTED_DAYLIGHT_DETECTOR_TATER).build();
     public static final BlockEntityType<BellTaterBlockEntity> BELL_TATER_ENTITY = FabricBlockEntityTypeBuilder.create(BellTaterBlockEntity::new, BELL_TATER).build();
@@ -544,6 +546,8 @@ public class NEBlocks {
 
         registerBlockEntity("launch_pad", LAUNCH_PAD_ENTITY);
         registerBlockEntity("contributor_statue", CONTRIBUTOR_STATUE_ENTITY);
+        registerBlockEntity("infinite_dispenser", INFINITE_DISPENSER_ENTITY);
+        registerBlockEntity("infinite_dropper", INFINITE_DROPPER_ENTITY);
         registerBlockEntity("tateroid", TATEROID_ENTITY);
         registerBlockEntity("daylight_detector_tater", DAYLIGHT_DETECTOR_TATER_ENTITY);
         registerBlockEntity("bell_tater", BELL_TATER_ENTITY);

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDispenserBlock.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDispenserBlock.java
@@ -1,10 +1,12 @@
 package xyz.nucleoid.extras.lobby.block;
 
 import eu.pb4.polymer.core.api.block.PolymerBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.dispenser.DispenserBehavior;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.block.entity.DispenserBlockEntity;
 import net.minecraft.item.ItemStack;
@@ -13,6 +15,7 @@ import net.minecraft.util.math.BlockPointer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldEvents;
 import net.minecraft.world.event.GameEvent;
+import xyz.nucleoid.extras.lobby.NEBlocks;
 import xyz.nucleoid.packettweaker.PacketContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,12 +27,20 @@ public class InfiniteDispenserBlock extends DispenserBlock implements PolymerBlo
         super(settings);
     }
 
+    protected Block getVirtualBlock() {
+        return Blocks.DISPENSER;
+    }
+
+    protected BlockEntityType<? extends DispenserBlockEntity> getBlockEntityType() {
+        return NEBlocks.INFINITE_DISPENSER_ENTITY;
+    }
+
     @Override
     protected void dispense(ServerWorld world, BlockState state, BlockPos pos) {
-        DispenserBlockEntity blockEntity = world.getBlockEntity(pos, BlockEntityType.DISPENSER).orElse(null);
+        DispenserBlockEntity blockEntity = world.getBlockEntity(pos, this.getBlockEntityType()).orElse(null);
 
         if (blockEntity == null) {
-            LOGGER.warn("Ignoring dispensing attempt for Infinite Dispenser without matching block entity at {}", pos);
+            LOGGER.warn("Ignoring dispensing attempt for " + this.getName().getString() + " without matching block entity at {}", pos);
         } else {
             BlockPointer pointer = new BlockPointer(world, pos, state, blockEntity);
 
@@ -51,8 +62,11 @@ public class InfiniteDispenserBlock extends DispenserBlock implements PolymerBlo
 
     @Override
     public BlockState getPolymerBlockState(BlockState state, PacketContext context) {
-        return Blocks.DISPENSER.getDefaultState()
-            .with(FACING, state.get(FACING))
-            .with(TRIGGERED, state.get(TRIGGERED));
+        return this.getVirtualBlock().getStateWithProperties(state);
+    }
+
+    @Override
+    public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+        return new InfiniteDispenserBlockEntity(pos, state);
     }
 }

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDispenserBlockEntity.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDispenserBlockEntity.java
@@ -1,0 +1,17 @@
+package xyz.nucleoid.extras.lobby.block;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.DispenserBlockEntity;
+import net.minecraft.util.math.BlockPos;
+import xyz.nucleoid.extras.lobby.NEBlocks;
+
+public class InfiniteDispenserBlockEntity extends DispenserBlockEntity {
+    protected InfiniteDispenserBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
+        super(type, pos, state);
+    }
+
+    public InfiniteDispenserBlockEntity(BlockPos pos, BlockState state) {
+        this(NEBlocks.INFINITE_DISPENSER_ENTITY, pos, state);
+    }
+}

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDropperBlock.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDropperBlock.java
@@ -1,15 +1,17 @@
 package xyz.nucleoid.extras.lobby.block;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.dispenser.DispenserBehavior;
 import net.minecraft.block.dispenser.ItemDispenserBehavior;
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.block.entity.DropperBlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.DispenserBlockEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import xyz.nucleoid.packettweaker.PacketContext;
+import xyz.nucleoid.extras.lobby.NEBlocks;
 
 public class InfiniteDropperBlock extends InfiniteDispenserBlock {
     private static final DispenserBehavior BEHAVIOR = new ItemDispenserBehavior();
@@ -19,17 +21,21 @@ public class InfiniteDropperBlock extends InfiniteDispenserBlock {
     }
     
     @Override
+    protected Block getVirtualBlock() {
+        return Blocks.DROPPER;
+    }
+
+    protected BlockEntityType<? extends DispenserBlockEntity> getBlockEntityType() {
+        return NEBlocks.INFINITE_DROPPER_ENTITY;
+    }
+
+    @Override
     protected DispenserBehavior getBehaviorForItem(World world, ItemStack stack) {
         return BEHAVIOR;
     }
 
     @Override
     public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
-        return new DropperBlockEntity(pos, state);
-    }
-
-    @Override
-    public BlockState getPolymerBlockState(BlockState state, PacketContext context) {
-        return Blocks.DROPPER.getDefaultState();
+        return new InfiniteDropperBlockEntity(pos, state);
     }
 }

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDropperBlockEntity.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/InfiniteDropperBlockEntity.java
@@ -1,0 +1,17 @@
+package xyz.nucleoid.extras.lobby.block;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import xyz.nucleoid.extras.lobby.NEBlocks;
+
+public class InfiniteDropperBlockEntity extends InfiniteDispenserBlockEntity {
+    public InfiniteDropperBlockEntity(BlockPos pos, BlockState state) {
+        super(NEBlocks.INFINITE_DROPPER_ENTITY, pos, state);
+    }
+
+    @Override
+    protected Text getContainerName() {
+        return Text.translatable("container.dropper");
+    }
+}


### PR DESCRIPTION
This pull request introduces `nucleoid_extras:infinite_dispenser` and `nucleoid_extras:infinite_dropper` block entity types, which fixes several overlapping issues:

- Attempting to work with infinite dispensers and droppers at all would crash the game, due to Minecraft 1.21.1's strict block entity supported block validation
- Prior to the above issue, infinite droppers would log a warning instead of dropping items
- Infinite droppers would not rotate correctly for clients