### PR TITLE
Add error reporting for loading invalid games

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/error/ExtrasErrorReporter.java
+++ b/src/main/java/xyz/nucleoid/extras/error/ExtrasErrorReporter.java
@@ -1,7 +1,9 @@
 package xyz.nucleoid.extras.error;
 
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.ReportType;
 import org.jetbrains.annotations.Nullable;
@@ -10,8 +12,10 @@ import xyz.nucleoid.plasmid.api.event.GameEvents;
 import xyz.nucleoid.plasmid.api.game.GameCloseReason;
 import xyz.nucleoid.plasmid.api.game.GameLifecycle;
 import xyz.nucleoid.plasmid.api.game.GameSpace;
+import xyz.nucleoid.plasmid.api.game.GameType;
 import xyz.nucleoid.plasmid.api.game.config.GameConfig;
 import xyz.nucleoid.plasmid.api.game.config.GameConfigs;
+import xyz.nucleoid.plasmid.impl.Plasmid;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -21,13 +25,35 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 public final class ExtrasErrorReporter {
     public static final CustomErrorType TOO_FAST = new CustomErrorType(Duration.ofMinutes(1));
+    public static final CustomErrorType INVALID_GAMES = new CustomErrorType(Duration.ofMinutes(1));
 
     private static final Map<CustomErrorType, Instant> LAST_REPORT = new ConcurrentHashMap<>();
 
     public static void register() {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            var invalidType = GameType.get(Identifier.of(Plasmid.ID, "invalid"));
+
+            var invalidGames = server.getRegistryManager()
+                    .getOrThrow(GameConfigs.REGISTRY_KEY)
+                    .streamEntries()
+                    .filter(entry -> entry.value().type() == invalidType)
+                    .map(ExtrasErrorReporter::sourceName)
+                    .map(entry -> " - " + entry)
+                    .sorted()
+                    .toList();
+
+            if (!invalidGames.isEmpty()) {
+                var lines = String.join("\n", invalidGames);
+                var trace = String.format("Loaded %d invalid game(s):\n\n%s", invalidGames.size(), lines);
+
+                reportCustom(INVALID_GAMES, trace);
+            }
+        });
+
         GameEvents.OPENED.register((game, gameSpace) -> {
             var config = NucleoidExtrasConfig.get();
             var errorReporting = config.errorReporting();
@@ -67,6 +93,18 @@ public final class ExtrasErrorReporter {
     }
 
     public static void reportCustom(CustomErrorType type, Throwable throwable) {
+        reportCustom(type, writer -> {
+            throwable.printStackTrace(new PrintWriter(writer));
+        });
+    }
+
+    public static void reportCustom(CustomErrorType type, String trace) {
+        reportCustom(type, writer -> {
+            writer.write(trace);
+        });
+    }
+
+    private static void reportCustom(CustomErrorType type, Consumer<StringWriter> trace) {
         if (!updateLastReportTime(type, Instant.now())) {
             return;
         }
@@ -74,7 +112,7 @@ public final class ExtrasErrorReporter {
         if (webhook != null) {
             var message = new DiscordWebhook.Message("An error has occurred!");
             try (var writer = new StringWriter()) {
-                throwable.printStackTrace(new PrintWriter(writer));
+                trace.accept(writer);
                 message.addFile("trace.txt", writer.toString());
                 webhook.post(message);
             } catch (IOException e) {


### PR DESCRIPTION
This pull request implements error reporting for Plasmid's invalid games functionality. Much like invalid games, this reporting is very much an interim solution; ideally, the server wrapper would handle data pack errors and revert games accordingly. Until then, a list of all games considered invalid would be helpful for fixing bugs caused by missing games or changes in data formats.