### PR TITLE
Add a tag for collectable tater blocks

### DIFF
--- a/src/datagen/java/xyz/nucleoid/extras/data/provider/NEAdvancementProvider.java
+++ b/src/datagen/java/xyz/nucleoid/extras/data/provider/NEAdvancementProvider.java
@@ -147,7 +147,7 @@ public class NEAdvancementProvider extends FabricAdvancementProvider {
     private static Advancement.Builder requiringTatersCollected(TaterCount count) {
         var builder = Advancement.Builder.createUntelemetered();
 
-        var name = "get_" + count.count() + "_tater" + (count.count() == 1 ? "" : "s");
+        var name = "get_" + count.count(null) + "_tater" + (count.count(null) == 1 ? "" : "s");
         var conditions = new TaterCollectedCriterion.Conditions(Optional.empty(), Optional.of(count));
 
         builder.criterion(name, NECriteria.TATER_COLLECTED.create(conditions));

--- a/src/datagen/java/xyz/nucleoid/extras/data/provider/NEBlockTagProvider.java
+++ b/src/datagen/java/xyz/nucleoid/extras/data/provider/NEBlockTagProvider.java
@@ -8,6 +8,7 @@ import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.RegistryWrapper.WrapperLookup;
 import net.minecraft.registry.tag.BlockTags;
 import xyz.nucleoid.extras.lobby.NEBlocks;
+import xyz.nucleoid.extras.lobby.block.tater.TinyPotatoBlock;
 import xyz.nucleoid.extras.tag.NEBlockTags;
 
 public class NEBlockTagProvider extends FabricTagProvider.BlockTagProvider {
@@ -17,6 +18,10 @@ public class NEBlockTagProvider extends FabricTagProvider.BlockTagProvider {
 
     @Override
     protected void configure(WrapperLookup lookup) {
+        for (var block : TinyPotatoBlock.TATERS) {
+            this.getOrCreateTagBuilder(NEBlockTags.COLLECTABLE_TATERS).add(block);
+        }
+
         this.getOrCreateTagBuilder(BlockTags.DOORS)
                 .add(NEBlocks.TRANSIENT_IRON_DOOR)
                 .add(NEBlocks.TRANSIENT_COPPER_DOOR)

--- a/src/main/java/xyz/nucleoid/extras/lobby/PlayerLobbyState.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/PlayerLobbyState.java
@@ -82,7 +82,7 @@ public class PlayerLobbyState {
     }
 
     private ActionResult collectTater(Block block, ItemStack stack, ServerPlayerEntity player) {
-        if (!NEItems.canUseTaters(player) || !(block instanceof TinyPotatoBlock tater)) return ActionResult.PASS;
+        if (!NEItems.canUseTaters(player) || !(block instanceof TinyPotatoBlock tater) || !tater.isCollectable()) return ActionResult.PASS;
 
         boolean alreadyAdded = this.collectedTaters.contains(tater);
 

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/tater/TinyPotatoBlock.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/tater/TinyPotatoBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.world.World;
+import xyz.nucleoid.extras.tag.NEBlockTags;
 import xyz.nucleoid.extras.util.SkinEncoder;
 
 import java.util.ArrayList;
@@ -95,6 +96,9 @@ public abstract class TinyPotatoBlock extends Block implements PolymerBlock {
         return false;
     }
 
+    public boolean isCollectable() {
+        return this.getDefaultState().isIn(NEBlockTags.COLLECTABLE_TATERS);
+    }
 
     public final String getItemTexture() {
         return this.texture;

--- a/src/main/java/xyz/nucleoid/extras/lobby/criterion/TaterCollectedCriterion.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/criterion/TaterCollectedCriterion.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public class TaterCollectedCriterion extends AbstractCriterion<TaterCollectedCriterion.Conditions> {
 	public void trigger(ServerPlayerEntity player, TinyPotatoBlock tater, int count) {
-		this.trigger(player, conditions -> conditions.matches(tater, count));
+		this.trigger(player, conditions -> conditions.matches(player, tater, count));
 	}
 
     @Override
@@ -36,9 +36,9 @@ public class TaterCollectedCriterion extends AbstractCriterion<TaterCollectedCri
             this.count = count;
         }
 
-        public boolean matches(TinyPotatoBlock tater, int count) {
+        public boolean matches(ServerPlayerEntity player, TinyPotatoBlock tater, int count) {
             boolean taterMatches = this.tater.isEmpty() || this.tater.get().value() == tater;
-            boolean countMatches = this.count.isEmpty() || this.count.get().matches(count);
+            boolean countMatches = this.count.isEmpty() || this.count.get().matches(player.getRegistryManager(), count);
             return taterMatches && countMatches;
         }
 

--- a/src/main/java/xyz/nucleoid/extras/tag/NEBlockTags.java
+++ b/src/main/java/xyz/nucleoid/extras/tag/NEBlockTags.java
@@ -6,6 +6,7 @@ import net.minecraft.registry.tag.TagKey;
 import xyz.nucleoid.extras.NucleoidExtras;
 
 public final class NEBlockTags {
+    public static final TagKey<Block> COLLECTABLE_TATERS = of("collectable_taters");
     public static final TagKey<Block> LUCKY_TATER_DROPS = of("lucky_tater_drops");
     public static final TagKey<Block> NON_VIBRATING_TATERS = of("non_vibrating_taters");
     public static final TagKey<Block> VIRAL_TATERS = of("viral_taters");


### PR DESCRIPTION
This pull request introduces a `#nucleoid_extras:collectable_taters` block tag, which can be used to restrict the taters that are collectable and shown in the tater box. By default, every tater is included in this block tag.