### PR TITLE
Allow customizing launcher sounds

### DIFF
--- a/src/main/java/xyz/nucleoid/extras/component/LauncherComponent.java
+++ b/src/main/java/xyz/nucleoid/extras/component/LauncherComponent.java
@@ -3,14 +3,19 @@ package xyz.nucleoid.extras.component;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import eu.pb4.polymer.core.api.other.PolymerComponent;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.sound.SoundEvent;
 
-public record LauncherComponent(float pitch, float power) implements PolymerComponent {
-    public static final LauncherComponent DEFAULT = new LauncherComponent(10, 4);
+import java.util.Optional;
+
+public record LauncherComponent(float pitch, float power, Optional<RegistryEntry<SoundEvent>> sound) implements PolymerComponent {
+    public static final LauncherComponent DEFAULT = new LauncherComponent(10, 4, Optional.empty());
 
     public static final Codec<LauncherComponent> CODEC = RecordCodecBuilder.create(instance ->
         instance.group(
                 Codec.FLOAT.optionalFieldOf("pitch", DEFAULT.pitch).forGetter(LauncherComponent::pitch),
-                Codec.FLOAT.optionalFieldOf("power", DEFAULT.power).forGetter(LauncherComponent::power)
+                Codec.FLOAT.optionalFieldOf("power", DEFAULT.power).forGetter(LauncherComponent::power),
+                SoundEvent.ENTRY_CODEC.optionalFieldOf("sound").forGetter(LauncherComponent::sound)
         ).apply(instance, LauncherComponent::new)
     );
 }

--- a/src/main/java/xyz/nucleoid/extras/lobby/block/LaunchPadBlockEntity.java
+++ b/src/main/java/xyz/nucleoid/extras/lobby/block/LaunchPadBlockEntity.java
@@ -3,17 +3,26 @@ package xyz.nucleoid.extras.lobby.block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.dynamic.Codecs;
 import net.minecraft.util.math.BlockPos;
 import xyz.nucleoid.extras.component.LauncherComponent;
 import xyz.nucleoid.extras.lobby.NEBlocks;
 
+import java.util.Optional;
+
 public class LaunchPadBlockEntity extends BlockEntity {
     public static final String PITCH_KEY = "Pitch";
     public static final String POWER_KEY = "Power";
+    public static final String SOUND_KEY = "sound";
 
     private float pitch = LauncherComponent.DEFAULT.pitch();
     private float power = LauncherComponent.DEFAULT.power();
+
+    private Optional<RegistryEntry<SoundEvent>> sound = LauncherComponent.DEFAULT.sound();
 
     public LaunchPadBlockEntity(BlockPos pos, BlockState state) {
         super(NEBlocks.LAUNCH_PAD_ENTITY, pos, state);
@@ -27,17 +36,39 @@ public class LaunchPadBlockEntity extends BlockEntity {
         return this.power;
     }
 
+    public Optional<RegistryEntry<SoundEvent>> getSound() {
+        return this.sound;
+    }
+
     @Override
     protected void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registries) {
         super.writeNbt(nbt, registries);
+
         nbt.putFloat(PITCH_KEY, this.pitch);
         nbt.putFloat(POWER_KEY, this.power);
+
+        if (this.sound.isPresent()) {
+            Codecs.optional(SoundEvent.ENTRY_CODEC)
+                    .encodeStart(registries.getOps(NbtOps.INSTANCE), this.sound)
+                    .result()
+                    .ifPresent(sound -> nbt.put(SOUND_KEY, sound));
+        }
     }
 
     @Override
     public void readNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registries) {
         super.readNbt(nbt, registries);
+
         this.pitch = nbt.getFloat(PITCH_KEY);
         this.power = nbt.getFloat(POWER_KEY);
+
+        if (nbt.contains(SOUND_KEY)) {
+            Codecs.optional(SoundEvent.ENTRY_CODEC)
+                    .parse(registries.getOps(NbtOps.INSTANCE), nbt.get(SOUND_KEY))
+                    .result()
+                    .ifPresent(sound -> this.sound = sound);
+        } else {
+            this.sound = Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces custom sound support for launch feathers and launch pads. The `sound` field of the launch pad block entity or launcher component allows a direct or referenced sound event to be specified. For example:

```mcfunction
# Obtain a launch feather that plays a burp sound when a player is launched
give @s nucleoid_extras:launch_feather[nucleoid_extras:launcher={sound:"entity.player.burp"}]

# Make a launch pad play a wind burst sound when a player is launched
data modify block ~ ~ ~ sound set value "entity.wind_charge.wind_burst"
```